### PR TITLE
Added link to download credentials

### DIFF
--- a/calendar/quickstart/README.md
+++ b/calendar/quickstart/README.md
@@ -14,9 +14,9 @@ composer install
 
 ### Download Developer Credentials
 
-- Follow the steps in the quickstart instructions to download your developer
+- Follow [the steps in the quickstart instructions](https://github.com/googleapis/google-api-php-client/blob/master/docs/oauth-web.md#create-authorization-credentials) to download your developer
   credentials and save them in a file called `credentails.json` in this
-  directory.
+  directory. Please make sure you are using "Desktop" application type.
 
 ## Run
 


### PR DESCRIPTION
It took some time for me to understand how to get `credentials.json`. Having this link in documents should make it much simpler.