### PR TITLE
chore: upgrade PHP samples to use namespaces

### DIFF
--- a/admin-sdk/directory/composer.json
+++ b/admin-sdk/directory/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/admin-sdk/directory/quickstart.php
+++ b/admin-sdk/directory/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Directory;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('G Suite Directory API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/admin.directory.user.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Directory($client);
+$service = new Directory($client);
 
 // Print the first 10 users in the domain.
 try{

--- a/admin-sdk/reports/composer.json
+++ b/admin-sdk/reports/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/admin-sdk/reports/quickstart.php
+++ b/admin-sdk/reports/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Reports;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Reports API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/admin.reports.audit.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Reports($client);
+$service = new Reports($client);
 
 // Print the last 10 login events.
 $userKey = 'all';

--- a/admin-sdk/reseller/composer.json
+++ b/admin-sdk/reseller/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/admin-sdk/reseller/quickstart.php
+++ b/admin-sdk/reseller/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Reseller;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('G Suite Reseller API PHP Quickstart');
     $client->setScopes("https://www.googleapis.com/auth/apps.order");
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Reseller($client);
+$service = new Reseller($client);
 
 // Print the first 10 subscriptions you manage.
 $optParams = array(

--- a/apps-script/execute/execute.php
+++ b/apps-script/execute/execute.php
@@ -18,14 +18,16 @@
 // [START apps_script_api_execute]
 require __DIR__ . '/vendor/autoload.php';
 
+use Google\Service\Script;
+
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Script($client);
+$service = new Script($client);
 
 $scriptId = 'ENTER_YOUR_SCRIPT_ID_HERE';
 
 // Create an execution request object.
-$request = new Google_Service_Script_ExecutionRequest();
+$request = new Script\ExecutionRequest();
 $request->setFunction('getFoldersUnderRoot');
 
 try {

--- a/apps-script/quickstart/composer.json
+++ b/apps-script/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/apps-script/quickstart/quickstart.php
+++ b/apps-script/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Script;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Apps Script API PHP Quickstart');
     $client->setScopes("https://www.googleapis.com/auth/script.projects");
     $client->setAuthConfig('credentials.json');
@@ -82,12 +85,12 @@ function getClient()
  * project, and log the script's URL to the user.
  */
 $client = getClient();
-$service = new Google_Service_Script($client);
+$service = new Script($client);
 
 // Create a management request object.
 try{
 
-    $request = new Google_Service_Script_CreateProjectRequest();
+    $request = new Script\CreateProjectRequest();
     $request->setTitle('My Script');
     $response = $service->projects->create($request);
 
@@ -98,7 +101,7 @@ function helloWorld() {
   console.log('Hello, world!');
 }
 EOT;
-    $file1 = new Google_Service_Script_ScriptFile();
+    $file1 = new Script\ScriptFile();
     $file1->setName('hello');
     $file1->setType('SERVER_JS');
     $file1->setSource($code);
@@ -109,12 +112,12 @@ EOT;
   "exceptionLogging": "CLOUD"
 }
 EOT;
-    $file2 = new Google_Service_Script_ScriptFile();
+    $file2 = new Script\ScriptFile();
     $file2->setName('appsscript');
     $file2->setType('JSON');
     $file2->setSource($manifest);
 
-    $request = new Google_Service_Script_Content();
+    $request = new Script\Content();
     $request->setScriptId($scriptId);
     $request->setFiles([$file1, $file2]);
 

--- a/calendar/quickstart/composer.json
+++ b/calendar/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/calendar/quickstart/quickstart.php
+++ b/calendar/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Calendar;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Calendar API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/calendar.events.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Calendar($client);
+$service = new Calendar($client);
 
 // Print the next 10 events on the user's calendar.
 try{

--- a/classroom/quickstart/composer.json
+++ b/classroom/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/classroom/quickstart/quickstart.php
+++ b/classroom/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Classroom;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Classroom API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/classroom.courses.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Classroom($client);
+$service = new Classroom($client);
 
 // Print the first 10 courses the user has access to.
 try{

--- a/docs/quickstart/composer.json
+++ b/docs/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/docs/quickstart/quickstart.php
+++ b/docs/quickstart/quickstart.php
@@ -17,13 +17,16 @@
 // [START docs_quickstart]
 require __DIR__ . '/vendor/autoload.php';
 
+use Google\Client;
+use Google\Service\Docs;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Docs API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/documents.readonly	');
     $client->setAuthConfig('credentials.json');
@@ -76,7 +79,7 @@ function expandHomeDirectory($path)
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Docs($client);
+$service = new Docs($client);
 
 // Prints the title of the requested doc:
 // https://docs.google.com/document/d/195j9eDD3ccgjQRttHhJPymLJUCOUjs-jmwTrekvdjFE/edit

--- a/docs/samples/composer.json
+++ b/docs/samples/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/apiclient": "^2.2",
+        "google/apiclient": "^2.10",
         "duncan3dc/cache": "~0.4"
     },
     "require-dev": {

--- a/docs/samples/extract_text.php
+++ b/docs/samples/extract_text.php
@@ -32,13 +32,16 @@ list($_, $documentId) = $argv;
 # [START docs_extract_text]
 // $documentId = 'YOUR_DOCUMENT_ID';
 
+use Google\Client;
+use Google\Service\Docs;
+
 /**
  * Create an authorized API client.
  * Be sure you've set up your OAuth2 consent screen at
  * https://console.cloud.google.com/apis/credentials/consent
  */
-$client = new Google_Client();
-$client->setScopes(Google_Service_Docs::DOCUMENTS_READONLY);
+$client = new Client();
+$client->setScopes(Docs::DOCUMENTS_READONLY);
 $client->setAuthConfig('credentials.json');
 $client->setAccessType('offline');
 
@@ -116,7 +119,7 @@ function read_structural_elements($elements)
 }
 
 // Fetch the document and print all text elements
-$service = new Google_Service_Docs($client);
+$service = new Docs($client);
 $doc = $service->documents->get($documentId);
 echo read_structural_elements($doc->getBody()->getContent());
 # [END docs_extract_text]

--- a/docs/samples/output_as_json.php
+++ b/docs/samples/output_as_json.php
@@ -29,6 +29,9 @@ if (count($argv) != 2) {
 }
 list($_, $documentId) = $argv;
 
+use Google\Client;
+use Google\Service\Docs;
+
 # [START docs_output_as_json]
 // $documentId = 'YOUR_DOCUMENT_ID';
 
@@ -37,8 +40,8 @@ list($_, $documentId) = $argv;
  * Be sure you've set up your OAuth2 consent screen at
  * https://console.cloud.google.com/apis/credentials/consent
  */
-$client = new Google_Client();
-$client->setScopes(Google_Service_Docs::DOCUMENTS_READONLY);
+$client = new Client();
+$client->setScopes(Docs::DOCUMENTS_READONLY);
 $client->setAuthConfig('credentials.json');
 $client->setAccessType('offline');
 
@@ -73,7 +76,7 @@ if ($client->isAccessTokenExpired()) {
 }
 
 // Fetch the document and print the results as formatted JSON
-$service = new Google_Service_Docs($client);
+$service = new Docs($client);
 $doc = $service->documents->get($documentId);
 print(json_encode((array) $doc, JSON_PRETTY_PRINT));
 # [END docs_output_as_json]

--- a/drive/activity-v2/composer.json
+++ b/drive/activity-v2/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/drive/activity-v2/quickstart.php
+++ b/drive/activity-v2/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\DriveActivity;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Drive Activity API Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/drive.activity.readonly');
     $client->setAuthConfig('credentials.json');
@@ -76,10 +79,10 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_DriveActivity($client);
+$service = new DriveActivity($client);
 
 // Print the recent activity in your Google Drive.
-$request = new Google_Service_DriveActivity_QueryDriveActivityRequest();
+$request = new DriveActivity\QueryDriveActivityRequest();
 $request->setPageSize(10);
 $results = $service->activity->query($request);
 

--- a/drive/activity/composer.json
+++ b/drive/activity/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/drive/activity/quickstart.php
+++ b/drive/activity/quickstart.php
@@ -21,15 +21,18 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Appsactivity;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Drive Activity API Quickstart');
-    $client->setScopes(Google_Service_Appsactivity::ACTIVITY);
+    $client->setScopes(Appsactivity::ACTIVITY);
     $client->setAuthConfig('credentials.json');
     $client->setAccessType('offline');
     $client->setPrompt('select_account consent');
@@ -76,7 +79,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Appsactivity($client);
+$service = new Appsactivity($client);
 
 // Print the recent activity in your Google Drive.
 $optParams = array(

--- a/drive/quickstart/composer.json
+++ b/drive/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/drive/quickstart/quickstart.php
+++ b/drive/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Drive;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Drive API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/drive.metadata.readonly');
     $client->setAuthConfig('credentials.json');
@@ -85,7 +88,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Drive($client);
+$service = new Drive($client);
 
 // Print the names and IDs for up to 10 files.
 $optParams = array(

--- a/drive/snippets/src/DriveSnippets.php
+++ b/drive/snippets/src/DriveSnippets.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+use Google\Service\Drive;
+
 class DriveSnippets
 {
     public function __construct($service)
@@ -26,7 +28,7 @@ class DriveSnippets
     {
         $driveService = $this->service;
         // [START drive_upload_basic]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'photo.jpg'));
         $content = file_get_contents('files/photo.jpg');
         $file = $driveService->files->create($fileMetadata, array(
@@ -47,7 +49,7 @@ class DriveSnippets
         // [START_EXCLUDE silent]
         $folderId = $realFolderId;
         // [END_EXCLUDE]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'photo.jpg',
             'parents' => array($folderId)
         ));
@@ -66,7 +68,7 @@ class DriveSnippets
     {
         $driveService = $this->service;
         // [START drive_upload_with_conversion]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'My Report',
             'mimeType' => 'application/vnd.google-apps.spreadsheet'));
         $content = file_get_contents('files/report.csv');
@@ -115,7 +117,7 @@ class DriveSnippets
     {
         $driveService = $this->service;
         // [START drive_create_shortcut]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'Project plan',
             'mimeType' => 'application/vnd.google-apps.drive-sdk'));
         $file = $driveService->files->create($fileMetadata, array(
@@ -130,7 +132,7 @@ class DriveSnippets
         $driveService = $this->service;
         // [START drive_touch_file]
         $fileId = '1sTWaJ_j7PkjzaBWtNc3IzovK5hQf21FbOw9yLeeLPNQ';
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'modifiedTime' => date('Y-m-d\TH:i:s.uP')));
         // [START_EXCLUDE silent]
         $fileId = $realFileId;
@@ -147,7 +149,7 @@ class DriveSnippets
     {
         $driveService = $this->service;
         // [START drive_create_folder]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'Invoices',
             'mimeType' => 'application/vnd.google-apps.folder'));
         $file = $driveService->files->create($fileMetadata, array(
@@ -163,7 +165,7 @@ class DriveSnippets
         // [START drive_move_file_to_folder]
         $fileId = '1sTWaJ_j7PkjzaBWtNc3IzovK5hQf21FbOw9yLeeLPNQ';
         $folderId = '0BwwA4oUTeiV1TGRPeTVjaWRDY1E';
-        $emptyFileMetadata = new Google_Service_Drive_DriveFile();
+        $emptyFileMetadata = new Drive\DriveFile();
         // [START_EXCLUDE silent]
         $fileId = $realFileId;
         $folderId = $realFolderId;
@@ -219,7 +221,7 @@ class DriveSnippets
         try {
             $batch = $driveService->createBatch();
 
-            $userPermission = new Google_Service_Drive_Permission(array(
+            $userPermission = new Drive\Permission(array(
                 'type' => 'user',
                 'role' => 'writer',
                 'emailAddress' => 'user@example.com'
@@ -230,7 +232,7 @@ class DriveSnippets
             $request = $driveService->permissions->create(
                 $fileId, $userPermission, array('fields' => 'id'));
             $batch->add($request, 'user');
-            $domainPermission = new Google_Service_Drive_Permission(array(
+            $domainPermission = new Drive\Permission(array(
                 'type' => 'domain',
                 'role' => 'reader',
                 'domain' => 'example.com'
@@ -244,7 +246,7 @@ class DriveSnippets
             $results = $batch->execute();
 
             foreach ($results as $result) {
-                if ($result instanceof Google_Service_Exception) {
+                if ($result instanceof Exception) {
                     // Handle error
                     printf($result);
                 } else {
@@ -265,7 +267,7 @@ class DriveSnippets
     {
         $driveService = $this->service;
         // [START drive_upload_app_data]
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'config.json',
             'parents' => array('appDataFolder')
         ));

--- a/drive/snippets/tests/BaseTestCase.php
+++ b/drive/snippets/tests/BaseTestCase.php
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 use Monolog\Logger;
+use Google\Client;
+use Google\Service\Docs;
 
 class BaseTestCase extends PHPUnit_Framework_TestCase
 {
@@ -45,13 +47,13 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     {
         // create a log channel
         $log = new Logger('debug');
-        $client = new Google_Client();
+        $client = new Client();
         $client->setApplicationName('Google Drive API Snippet Tests');
         $client->useApplicationDefaultCredentials();
         $client->addScope('https://www.googleapis.com/auth/drive');
         $client->addScope('https://www.googleapis.com/auth/drive.appdata');
         $client->setLogger($log);
-        return new Google_Service_Drive($client);
+        return new Drive($client);
     }
 
     protected function deleteFileOnCleanup($id)
@@ -61,7 +63,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
 
     protected function createTestDocument()
     {
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'Test document',
             'mimeType' => 'application/vnd.google-apps.document'));
         $content = file_get_contents('files/document.txt');
@@ -76,7 +78,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
 
     protected function createTestBlob()
     {
-        $fileMetadata = new Google_Service_Drive_DriveFile(array(
+        $fileMetadata = new Drive\DriveFile(array(
             'name' => 'photo.jpg'));
         $content = file_get_contents('files/photo.jpg');
         $file = self::$service->files->create($fileMetadata, array(

--- a/gmail/quickstart/composer.json
+++ b/gmail/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/gmail/quickstart/quickstart.php
+++ b/gmail/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Gmail;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Gmail API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/gmail.addons.current.message.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Gmail($client);
+$service = new Gmail($client);
 
 try{
 

--- a/people/quickstart/composer.json
+++ b/people/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/people/quickstart/quickstart.php
+++ b/people/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\PeopleService;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('People API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/contacts.other.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_PeopleService($client);
+$service = new PeopleService($client);
 
 // Print the names for up to 10 connections.
 try{

--- a/sheets/quickstart/composer.json
+++ b/sheets/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/sheets/quickstart/quickstart.php
+++ b/sheets/quickstart/quickstart.php
@@ -21,13 +21,15 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Google\Client();
     $client->setApplicationName('Google Sheets API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/spreadsheets');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +79,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Sheets($client);
+$service = new Google\Service\Sheets($client);
 
 // Prints the names and majors of students in a sample spreadsheet:
 // https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgvE2upms/edit

--- a/sheets/snippets/src/SpreadsheetSnippets.php
+++ b/sheets/snippets/src/SpreadsheetSnippets.php
@@ -14,6 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+use Google\Service\Sheets;
+
 class SpreadsheetSnippets
 {
     public function __construct($service)
@@ -25,7 +28,7 @@ class SpreadsheetSnippets
     {
         $service = $this->service;
         // [START sheets_create]
-        $spreadsheet = new Google_Service_Sheets_Spreadsheet([
+        $spreadsheet = new Sheets\Spreadsheet([
             'properties' => [
                 'title' => $title
             ]
@@ -44,7 +47,7 @@ class SpreadsheetSnippets
         // [START sheets_batch_update]
         $requests = [
           // Change the spreadsheet's title.
-          new Google_Service_Sheets_Request([
+          new Sheets\Request([
               'updateSpreadsheetProperties' => [
                   'properties' => [
                       'title' => $title
@@ -53,7 +56,7 @@ class SpreadsheetSnippets
               ]
           ]),
           // Find and replace text.
-          new Google_Service_Sheets_Request([
+          new Sheets\Request([
               'findReplace' => [
                   'find' => $find,
                   'replacement' => $replacement,
@@ -63,7 +66,7 @@ class SpreadsheetSnippets
         ];
 
         // Add additional requests (operations) ...
-        $batchUpdateRequest = new Google_Service_Sheets_BatchUpdateSpreadsheetRequest([
+        $batchUpdateRequest = new Sheets\BatchUpdateSpreadsheetRequest([
             'requests' => $requests
         ]);
 
@@ -120,7 +123,7 @@ class SpreadsheetSnippets
         // [START_EXCLUDE silent]
         $values = $_values;
         // [END_EXCLUDE]
-        $body = new Google_Service_Sheets_ValueRange([
+        $body = new Sheets\ValueRange([
             'values' => $values
         ]);
         $params = [
@@ -148,12 +151,12 @@ class SpreadsheetSnippets
         $values = $_values;
         // [END_EXCLUDE]
         $data = [];
-        $data[] = new Google_Service_Sheets_ValueRange([
+        $data[] = new Sheets\ValueRange([
             'range' => $range,
             'values' => $values
         ]);
         // Additional ranges to update ...
-        $body = new Google_Service_Sheets_BatchUpdateValuesRequest([
+        $body = new Sheets\BatchUpdateValuesRequest([
             'valueInputOption' => $valueInputOption,
             'data' => $data
         ]);
@@ -177,7 +180,7 @@ class SpreadsheetSnippets
         // [START_EXCLUDE silent]
         $values = $_values;
         // [END_EXCLUDE]
-        $body = new Google_Service_Sheets_ValueRange([
+        $body = new Sheets\ValueRange([
             'values' => $values
         ]);
         $params = [
@@ -193,14 +196,14 @@ class SpreadsheetSnippets
     {
         $service = $this->service;
         $requests = [
-            new Google_Service_Sheets_Request([
+            new Sheets\Request([
                 'addSheet' => [
                     'properties' => [
                         'title' => 'Sheet 1'
                     ]
                 ]
             ]),
-            new Google_Service_Sheets_Request([
+            new Sheets\Request([
                 'addSheet' => [
                     'properties' => [
                         'title' => 'Sheet 2'
@@ -209,7 +212,7 @@ class SpreadsheetSnippets
             ])
         ];
         // Create two sheets for our pivot table
-        $batchUpdateRequest = new Google_Service_Sheets_BatchUpdateSpreadsheetRequest([
+        $batchUpdateRequest = new Sheets\BatchUpdateSpreadsheetRequest([
             'requests' => $requests
         ]);
         $batchUpdateResponse = $service->spreadsheets->batchUpdate($spreadsheetId, $batchUpdateRequest);
@@ -279,7 +282,7 @@ class SpreadsheetSnippets
         ];
 
         $requests = [
-            new Google_Service_Sheets_Request([
+            new Sheets\Request([
                 'addConditionalFormatRule' => [
                     'rule' => [
                         'ranges' => [ $myRange ],
@@ -296,7 +299,7 @@ class SpreadsheetSnippets
                     'index' => 0
                 ]
             ]),
-            new Google_Service_Sheets_Request([
+            new Sheets\Request([
                 'addConditionalFormatRule' => [
                     'rule' => [
                         'ranges' => [ $myRange ],
@@ -315,7 +318,7 @@ class SpreadsheetSnippets
             ])
         ];
 
-        $batchUpdateRequest = new Google_Service_Sheets_BatchUpdateSpreadsheetRequest([
+        $batchUpdateRequest = new Sheets\BatchUpdateSpreadsheetRequest([
             'requests' => $requests
         ]);
         $response = $service->spreadsheets->batchUpdate($spreadsheetId, $batchUpdateRequest);

--- a/sheets/snippets/tests/BaseTestCase.php
+++ b/sheets/snippets/tests/BaseTestCase.php
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 use Monolog\Logger;
+use Google\Service\Drive;
+use Google\Service\Sheets;
+use Google\Client;
 
 class BaseTestCase extends PHPUnit_Framework_TestCase
 {
@@ -27,8 +30,8 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         $client = self::createClient();
-        BaseTestCase::$service = new Google_Service_Sheets($client);
-        BaseTestCase::$driveService = new Google_Service_Drive($client);
+        BaseTestCase::$service = new Sheets($client);
+        BaseTestCase::$driveService = new Drive($client);
     }
 
     protected function setUp()
@@ -51,7 +54,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     {
         // create a log channel
         $log = new Logger('debug');
-        $client = new Google_Client();
+        $client = new Client();
         $client->setApplicationName(self::APPLICATION_NAME);
         $client->useApplicationDefaultCredentials();
         $client->addScope('https://www.googleapis.com/auth/drive');
@@ -66,7 +69,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
 
     protected function createTestSpreadsheet()
     {
-        $spreadsheet = new Google_Service_Sheets_Spreadsheet([
+        $spreadsheet = new Sheets\Spreadsheet([
             'properties' => [
                 'title' => 'Test Spreadsheet'
             ]
@@ -95,7 +98,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
                 'fields' => 'userEnteredValue'
             ]
         ];
-        $body = new Google_Service_Sheets_BatchUpdateSpreadsheetRequest([
+        $body = new Sheets\BatchUpdateSpreadsheetRequest([
             'requests' => $requests
         ]);
         self::$service->spreadsheets->batchUpdate($spreadsheetId, $body);

--- a/slides/quickstart/composer.json
+++ b/slides/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/slides/quickstart/quickstart.php
+++ b/slides/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Slides;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Slides API PHP Quickstart');
     $client->setScopes("https://www.googleapis.com/auth/presentations");
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Slides($client);
+$service = new Slides($client);
 
 // Prints the number of slides and elements in a sample presentation:
 // https://docs.google.com/presentation/d/1EAYk18WDjIG-zp_0vLm3CsfQh_i8eXc67Jo2O9C6Vuc/edit

--- a/slides/snippets/composer.json
+++ b/slides/snippets/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     },
     "require-dev": {
         "phpunit/phpunit": "9.5.20",

--- a/slides/snippets/src/SlidesSnippets.php
+++ b/slides/snippets/src/SlidesSnippets.php
@@ -14,6 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+use Google\Service\Drive;
+use Google\Service\Slides;
+
 class SlidesSnippets
 {
     public function __construct($service, $driveService, $sheetsService)
@@ -27,7 +31,7 @@ class SlidesSnippets
     {
         $slidesService = $this->service;
         // [START slides_create_presentation]
-        $presentation = new Google_Service_Slides_Presentation(array(
+        $presentation = new Slides\Presentation(array(
             'title' => $title
         ));
 
@@ -41,7 +45,7 @@ class SlidesSnippets
     {
         $driveService = $this->driveService;
         // [START slides_copy_presentation]
-        $copy = new Google_Service_Drive_DriveFile(array(
+        $copy = new Drive\DriveFile(array(
             'name' => $copyTitle
         ));
         $driveResponse = $driveService->files->copy($presentationId, $copy);
@@ -57,7 +61,7 @@ class SlidesSnippets
         // Add a slide at index 1 using the predefined 'TITLE_AND_TWO_COLUMNS' layout and
         // the ID page_id.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createSlide' => array(
                 'objectId' => $pageId,
                 'insertionIndex' => 1,
@@ -71,7 +75,7 @@ class SlidesSnippets
         // using the page_id.
 
         // Execute the request.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -89,7 +93,7 @@ class SlidesSnippets
         $elementId = 'MyTextBox_01';
         $pt350 = array('magnitude' => 350, 'unit' => 'PT');
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createShape' => array(
                 'objectId' => $elementId,
                 'shapeType' => 'TEXT_BOX',
@@ -111,7 +115,7 @@ class SlidesSnippets
         ));
 
         // Insert text into the box, using the supplied element ID.
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'insertText' => array(
                 'objectId' => $elementId,
                 'insertionIndex' => 0,
@@ -120,7 +124,7 @@ class SlidesSnippets
         ));
 
         // Execute the requests.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -141,7 +145,7 @@ class SlidesSnippets
         $imageId = 'MyImage_01';
         $emu4M = array('magnitude' => 4000000, 'unit' => 'EMU');
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createImage' => array(
                 'objectId' => $imageId,
                 'url' => $imageUrl,
@@ -163,7 +167,7 @@ class SlidesSnippets
         ));
 
         // Execute the request.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -195,7 +199,7 @@ class SlidesSnippets
             $totalPortfolio = $row[11];  // total portfolio in column 12
 
             // Duplicate the template presentation using the Drive API.
-            $copy = new Google_Service_Drive_DriveFile(array(
+            $copy = new Drive\DriveFile(array(
                 'name' => $customerName . ' presentation'
             ));
             $driveResponse = $driveService->files->copy($templatePresentationId, $copy);
@@ -203,7 +207,7 @@ class SlidesSnippets
 
             // Create the text merge (replaceAllText) requests for this presentation.
             $requests = array();
-            $requests[] = new Google_Service_Slides_Request(array(
+            $requests[] = new Slides\Request(array(
                 'replaceAllText' => array(
                     'containsText' => array(
                         'text' => '{{customer-name}}',
@@ -212,7 +216,7 @@ class SlidesSnippets
                     'replaceText' => $customerName
                 )
             ));
-            $requests[] = new Google_Service_Slides_Request(array(
+            $requests[] = new Slides\Request(array(
                 'replaceAllText' => array(
                     'containsText' => array(
                         'text' => '{{case-description}}',
@@ -221,7 +225,7 @@ class SlidesSnippets
                     'replaceText' => $caseDescription
                 )
             ));
-            $requests[] = new Google_Service_Slides_Request(array(
+            $requests[] = new Slides\Request(array(
                 'replaceAllText' => array(
                     'containsText' => array(
                         'text' => '{{total-portfolio}}',
@@ -232,7 +236,7 @@ class SlidesSnippets
             ));
 
             // Execute the requests for this presentation.
-            $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+            $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
                 'requests' => $requests
             ));
             $response =
@@ -260,7 +264,7 @@ class SlidesSnippets
         $customerGraphicUrl = $imageUrl;
         // [START slides_image_merging]
         // Duplicate the template presentation using the Drive API.
-        $copy = new Google_Service_Drive_DriveFile(array(
+        $copy = new Drive\DriveFile(array(
             'name' => $customerName . ' presentation'
         ));
         $driveResponse = $driveService->files->copy($templatePresentationId, $copy);
@@ -268,7 +272,7 @@ class SlidesSnippets
 
         // Create the image merge (replaceAllShapesWithImage) requests.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'replaceAllShapesWithImage' => array(
                 'imageUrl' => $logoUrl,
                 'replaceMethod' => 'CENTER_INSIDE',
@@ -278,7 +282,7 @@ class SlidesSnippets
                 )
             )
         ));
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'replaceAllShapesWithImage' => array(
                 'imageUrl' => $customerGraphicUrl,
                 'replaceMethod' => 'CENTER_INSIDE',
@@ -290,7 +294,7 @@ class SlidesSnippets
         ));
 
         // Execute the requests.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response =
@@ -313,7 +317,7 @@ class SlidesSnippets
         // [START slides_simple_text_replace]
         // Remove existing text in the shape, then insert new text.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'deleteText' => array(
                 'objectId' => $shapeId,
                 'textRange' => array(
@@ -321,7 +325,7 @@ class SlidesSnippets
                 )
             )
         ));
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'insertText' => array(
                 'objectId' => $shapeId,
                 'insertionIndex' => 0,
@@ -330,7 +334,7 @@ class SlidesSnippets
         ));
 
         // Execute the requests.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -347,7 +351,7 @@ class SlidesSnippets
         // and italicized, the next 5 are displayed in blue 14 pt Times
         // New Roman font, and the next 5 are hyperlinked.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'updateTextStyle' => array(
                 'objectId' => $shapeId,
                 'textRange' => array(
@@ -362,7 +366,7 @@ class SlidesSnippets
                 'fields' => 'bold,italic'
             )
         ));
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'updateTextStyle' => array(
                 'objectId' => $shapeId,
                 'textRange' => array(
@@ -389,7 +393,7 @@ class SlidesSnippets
                 'fields' => 'foregroundColor,fontFamily,fontSize'
             )
         ));
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'updateTextStyle' => array(
                 'objectId' => $shapeId,
                 'textRange' => array(
@@ -407,7 +411,7 @@ class SlidesSnippets
         ));
 
         // Execute the requests.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -422,7 +426,7 @@ class SlidesSnippets
         // [START slides_create_bulleted_text]
         // Add arrow-diamond-disc bullets to all text in the shape.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createParagraphBullets' => array(
                 'objectId' => $shapeId,
                 'textRange' => array(
@@ -433,7 +437,7 @@ class SlidesSnippets
         ));
 
         // Execute the request.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -452,7 +456,7 @@ class SlidesSnippets
         $presentationChartId = 'MyEmbeddedChart';
         $emu4M = array('magnitude' => 4000000, 'unit' => 'EMU');
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createSheetsChart' => array(
                 'spreadsheetId' => $spreadsheetId,
                 'chartId' => $sheetChartId,
@@ -475,7 +479,7 @@ class SlidesSnippets
         ));
 
         // Execute the request.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -490,14 +494,14 @@ class SlidesSnippets
         // [START slides_refresh_sheets_chart]
         // Refresh an existing linked Sheets chart embedded in a presentation.
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'refreshSheetsChart' => array(
                 'objectId' => $presentationChartId
             )
         ));
 
         // Execute the request.
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = $slidesService->presentations->batchUpdate($presentationId, $batchUpdateRequest);

--- a/slides/snippets/tests/BaseTestCase.php
+++ b/slides/snippets/tests/BaseTestCase.php
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 use Monolog\Logger;
+use Google\Client;
+use Google\Service\Drive;
+use Google\Service\Sheets;
+use Google\Service\Slides;
 
 class BaseTestCase extends PHPUnit_Framework_TestCase
 {
@@ -27,9 +31,9 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         $client = self::createClient();
-        BaseTestCase::$service = new Google_Service_Slides($client);
-        BaseTestCase::$driveService = new Google_Service_Drive($client);
-        BaseTestCase::$sheetsService = new Google_Service_Sheets($client);
+        BaseTestCase::$service = new Slides($client);
+        BaseTestCase::$driveService = new Drive($client);
+        BaseTestCase::$sheetsService = new Sheets($client);
     }
 
     protected function setUp()
@@ -52,7 +56,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     {
         // create a log channel
         $log = new Logger('debug');
-        $client = new Google_Client();
+        $client = new Client();
         $client->setApplicationName(self::APPLICATION_NAME);
         $client->useApplicationDefaultCredentials();
         $client->addScope('https://www.googleapis.com/auth/drive');
@@ -67,7 +71,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
 
     protected function createTestPresentation()
     {
-        $presentation = new Google_Service_Slides_Presentation(array(
+        $presentation = new Slides\Presentation(array(
             'title' => 'Test Presentation'
         ));
         $presentation = self::$service->presentations->create($presentation);
@@ -78,13 +82,13 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
     protected function createTestSlide($presentationId)
     {
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createSlide' => array(
                 'objectId' => 'TestSlide',
                 'slideLayoutReference' => array('predefinedLayout' => 'BLANK')
             )
         ));
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = self::$service->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -96,7 +100,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
         $boxId = 'MyTextBox_01';
         $pt350 = array('magnitude' => 350, 'unit' => 'PT');
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createShape' => array(
                 'objectId' => $boxId,
                 'shapeType' => 'TEXT_BOX',
@@ -116,7 +120,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
                 )
             )
         ));
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'insertText' => array(
                 'objectId' => $boxId,
                 'insertionIndex' => 0,
@@ -124,7 +128,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
             )
         ));
 
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = self::$service->presentations->batchUpdate($presentationId, $batchUpdateRequest);
@@ -136,7 +140,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
         $chartId = 'MyChart_01';
         $emu4M = array('magnitude' => 4000000, 'unit' => 'EMU');
         $requests = array();
-        $requests[] = new Google_Service_Slides_Request(array(
+        $requests[] = new Slides\Request(array(
             'createSheetsChart' => array(
                 'objectId' => $chartId,
                 'spreadsheetId' => $spreadsheetId,
@@ -159,7 +163,7 @@ class BaseTestCase extends PHPUnit_Framework_TestCase
             )
         ));
 
-        $batchUpdateRequest = new Google_Service_Slides_BatchUpdatePresentationRequest(array(
+        $batchUpdateRequest = new Slides\BatchUpdatePresentationRequest(array(
             'requests' => $requests
         ));
         $response = self::$service->presentations->batchUpdate($presentationId, $batchUpdateRequest);

--- a/tasks/quickstart/composer.json
+++ b/tasks/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/tasks/quickstart/quickstart.php
+++ b/tasks/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Tasks;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Tasks API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/tasks.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Tasks($client);
+$service = new Tasks($client);
 
 // Print the first 10 task lists.
 try{

--- a/vault/quickstart/composer.json
+++ b/vault/quickstart/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "google/apiclient": "^2.2"
+        "google/apiclient": "^2.10"
     }
 }

--- a/vault/quickstart/quickstart.php
+++ b/vault/quickstart/quickstart.php
@@ -21,13 +21,16 @@ if (php_sapi_name() != 'cli') {
     throw new Exception('This application must be run on the command line.');
 }
 
+use Google\Client;
+use Google\Service\Vault;
+
 /**
  * Returns an authorized API client.
- * @return Google_Client the authorized client object
+ * @return Client the authorized client object
  */
 function getClient()
 {
-    $client = new Google_Client();
+    $client = new Client();
     $client->setApplicationName('Google Vault API PHP Quickstart');
     $client->setScopes('https://www.googleapis.com/auth/ediscovery.readonly');
     $client->setAuthConfig('credentials.json');
@@ -77,7 +80,7 @@ function getClient()
 
 // Get the API client and construct the service object.
 $client = getClient();
-$service = new Google_Service_Vault($client);
+$service = new Vault($client);
 
 // Print the first 10 matters.
 try{


### PR DESCRIPTION
Since version `2.10` of `google/apiclient`, namespaces have been available for PHP. This is better practice, and should be used instead of the outdated underscore method.