### PR TITLE
Change pageToken by nextPageToken

### DIFF
--- a/drive/snippets/drive_v3/src/DriveSearchFiles.php
+++ b/drive/snippets/drive_v3/src/DriveSearchFiles.php
@@ -38,7 +38,7 @@ function searchFiles()
             }
             array_push($files, $response->files);
 
-            $pageToken = $response->pageToken;
+            $pageToken = $response->nextPageToken;
         } while ($pageToken != null);
         return $files;
     } catch(Exception $e) {


### PR DESCRIPTION
## Fix

- Parameter `pageToken` return `null`. if we want get next response page, we have to get parameter  `nextPageToken`