### PR TITLE
Correctly define array - not multidimensional array

### DIFF
--- a/drive/snippets/drive_v3/src/DriveUploadBasic.php
+++ b/drive/snippets/drive_v3/src/DriveUploadBasic.php
@@ -28,11 +28,11 @@ function uploadBasic()
         $fileMetadata = new Drive\DriveFile(array(
         'name' => 'photo.jpg'));
         $content = file_get_contents('../files/photo.jpg');
-        $file = $driveService->files->create($fileMetadata, array([
+        $file = $driveService->files->create($fileMetadata, array(
             'data' => $content,
             'mimeType' => 'image/jpeg',
             'uploadType' => 'multipart',
-            'fields' => 'id']));
+            'fields' => 'id'));
         printf("File ID: %s\n", $file->id);
         return $file->id;
     } catch(Exception $e) {


### PR DESCRIPTION
I was going crazy today trying to figure out why I was getting 0 sized files on upload.   Finally I noticed that I had based my work on this sample code I found on this page:  https://developers.google.com/drive/api/guides/manage-uploads and the array of parameters was being doubly defined creating a multidimensional array instead of just passing parameters.

Removing either the array() or the [] around the array elements solves the problem.  I'm not sure which is the preferred coding style for this project as I see several other sample files that are also using both methods of defining an array.

I also see that the 'fields' parameter is being passed - but the API docs don't show that as a paramter for the create endpoint.  https://developers.google.com/drive/api/v3/reference/files/create so it appears that isn't needed either unless the api reference is out of date.
