### PR TITLE
Update SpreadsheetAppendValues.php

### DIFF
--- a/sheets/snippets/src/SpreadsheetAppendValues.php
+++ b/sheets/snippets/src/SpreadsheetAppendValues.php
@@ -45,8 +45,8 @@ function appendValues($spreadsheetId, $range, $valueInputOption)
         // TODO(developer) - handle error appropriately
         echo 'Message: ' . $e->getMessage();
     }
-    // [END sheets_append_values]
 }
+// [END sheets_append_values]
 
 require 'vendor/autoload.php';
 appendValues('1sN_EOj0aYp5hn9DeqSY72G7sKaFRg82CsMGnK_Tooa8', 'Sheet1!A1:B2', "RAW");


### PR DESCRIPTION
Misplaced `[END sheets_append_values]` comment is generating incorrect code snippet in the google doc (I guess)

see this code snippet, here we can see the function's closing brace is missing in the doc.

[https://developers.google.com/sheets/api/guides/values#append_values](https://developers.google.com/sheets/api/guides/values#append_values)

If I guessed it correctly then this issue is present in other code file as well.